### PR TITLE
Change/allow empty string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ npm-debug.log
 
 *.sublime-project
 *.sublime-workspace
+.npmrc

--- a/compatibility.md
+++ b/compatibility.md
@@ -15,3 +15,4 @@
     ```
 
     - The `type` (rule that failed) is always equal to the rule name that was called in the construction of the validator. This differs from the undocumented behaviour in Joi where, for example, failures on the `any.forbidden` would appear as failures of `any.unknown` and failures on the `any.valid` rule would appear as failures in `any.allowOnly`.
+- Unlike joi, `Jo.string()` allows empty strings, if you want to make sure empty strings are not allowed you can either use `.min(1)` or `.deny('')` instead.

--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -22,7 +22,7 @@ const hostnameRegEx = /^(([a-z\d]|[a-z\d][a-z\d\-]*[a-z\d])\.)*([a-z\d]|[a-z\d][
 
 class StringValidator extends SyncRule {
     validateSync(params) {
-        return typeof params.value === 'string' && params.value.length > 0;
+        return typeof params.value === 'string';
     }
 
     static ruleName() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jojen",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Expressive validator for Node and the browser, with a small footprint and awesome performance",
   "main": "dist/index",
   "scripts": {

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -67,8 +67,10 @@ chai.use((_chai, utils) => {
             if (options.joi !== false) {
                 joiError = Joi.validate(value, joiValid, options.validator).error;
             }
-
-            if (err && (!joiError && options.joi !== false) && !options.ignoreCompability) {
+            if (options.ignoreCompability) {
+                return;
+            }
+            if (err && (!joiError && options.joi !== false)) {
                 assert.fail(
                     err,
                     null,

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -5,7 +5,9 @@ describe('string', () => {
         expect(Jo => Jo.string()).to.failOn(1);
         expect(Jo => Jo.string()).to.failOn(null);
         expect(Jo => Jo.string()).to.failOn(false);
-        expect(Jo => Jo.string()).to.failOn('');
+        expect(Jo => Jo.string()).to.not.failOn('', {
+            ignoreCompability: true,
+        });
         expect(Jo => Jo.string()).to.not.failOn('a');
     });
 
@@ -25,7 +27,9 @@ describe('string', () => {
 
     it('will validate max string length', () => {
         // TODO: Encoding
-        expect(Jo => Jo.string().max(3)).to.failOn('');
+        expect(Jo => Jo.string().max(3)).to.not.failOn('', {
+            ignoreCompability: true,
+        });
         expect(Jo => Jo.string().max(3)).to.not.failOn('aaa');
         expect(Jo => Jo.string().max(3)).to.failOn('aaaa');
     });


### PR DESCRIPTION
I know this is not joi compatible, but there is also not much sense is explicitly disallowing empty strings, empty strings are still strings, if we want to enforce a minimum length we should do so through `min`.