### PR TITLE
Enforce that objects have a typeof objects

### DIFF
--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -1,10 +1,11 @@
 import Rule from '../types/rule';
+import SyncRule from '../types/syncRule';
 import { async, clone, assign } from '../util';
 
 
-class ObjectValidator extends Rule {
-    operates() {
-        return false;
+class ObjectValidator extends SyncRule {
+    validateSync(params) {
+        return params.value && typeof params.value === 'object';
     }
 
     static ruleName() {

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -1,6 +1,13 @@
 import Jo from '../lib';
 
 describe('object', () => {
+    it('validates types', () => {
+        expect(Jo => Jo.object()).not.to.failOn({});
+        expect(Jo => Jo.object()).to.failOn(null);
+        expect(Jo => Jo.object()).to.failOn(42);
+        expect(Jo => Jo.object()).to.failOn('nope');
+    });
+
     describe('keys', () => {
         it('restricts unknown', () => {
             expect((Jo) => Jo.object().keys({ a: Jo.any() })).to.failOn({ b: 42 }, [


### PR DESCRIPTION
Fixes a mismatch before where `object()` assumed anything was an object. Now it defines an object to be a not-null type where `typeof foo === 'object'`