### PR TITLE
Implement object.pattern(regex, schema)

### DIFF
--- a/lib/rules/array.js
+++ b/lib/rules/array.js
@@ -76,14 +76,12 @@ class Items extends Rule {
     }
 
     validate(params, callback) {
-        const todo = params.value.map((item, index) => {
+        return async.map(params.value, (item, index) => {
             const options = clone(params.options);
             options._path = options._path.concat(`[${index}]`);
 
             return (done) => params.validator.validate(item, this._schema, options, done);
-        });
-
-        async.all(todo, callback);
+        }, callback);
     }
 
     static ruleName() {
@@ -103,14 +101,12 @@ class Ordered extends Rule {
             return callback(this.error(params, { length, expected }));
         }
 
-        const todo = this._schemas.map((schema, index) => {
+        return async.map(this._schemas, (schema, index) => {
             const options = clone(params.options);
             options._path = options._path.concat(`[${index}]`);
 
             return (done) => params.validator.validate(params.value[index], schema, options, done);
-        });
-
-        return async.all(todo, callback);
+        }, callback);
     }
 
     static ruleName() {

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -61,7 +61,7 @@ class Keys extends Rule {
             return undefined;
         }
 
-        const todo = this._keys.map((key) => {
+        return async.map(this._keys, key => {
             const options = clone(params.options);
             options._path = options._path.concat(key);
 
@@ -83,9 +83,7 @@ class Keys extends Rule {
                     }
                 );
             };
-        });
-
-        return async.all(todo, callback);
+        }, callback);
     }
 
     static ruleName() {
@@ -101,15 +99,12 @@ class Pattern extends Rule {
 
     validate(params, callback) {
         const value = params.value;
-        if (value === undefined || value === null) {
-            return callback(this.error(params));
-        }
 
-        const todo = Object.keys(value).map((key) => {
+        return async.map(Object.keys(value), key => {
             const options = clone(params.options);
             options._path = options._path.concat(key);
 
-            return (done) => {
+            return done => {
                 if (!this._keyRegex.test(key)) {
                     done(this.error(params, { extra: key, rule: 'object.unknown' }));
                     return;
@@ -131,9 +126,7 @@ class Pattern extends Rule {
                         return done();
                     });
             };
-        });
-
-        return async.all(todo, callback);
+        }, callback);
     }
 
     static ruleName() {

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -93,6 +93,54 @@ class Keys extends Rule {
     }
 }
 
+class Pattern extends Rule {
+    compile(params) {
+        this._keyRegex = new RegExp(params.args[0]);
+        this._valueSchema = params.args[1];
+    }
+
+    validate(params, callback) {
+        const value = params.value;
+        if (value === undefined || value === null) {
+            return callback(this.error(params));
+        }
+
+        const todo = Object.keys(value).map((key) => {
+            const options = clone(params.options);
+            options._path = options._path.concat(key);
+
+            return (done) => {
+                if (!this._keyRegex.test(key)) {
+                    done(this.error(params, { extra: key, rule: 'object.unknown' }));
+                    return;
+                }
+
+                params.validator.validate(
+                    value[key],
+                    this._valueSchema,
+                    options,
+                    (err, converted) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        if (options.convert && converted !== undefined) {
+                            value[key] = converted;
+                        }
+
+                        return done();
+                    });
+            };
+        });
+
+        return async.all(todo, callback);
+    }
+
+    static ruleName() {
+        return 'object.pattern';
+    }
+}
+
 class Unknown extends Rule {
     compile(params) {
         const allow = params.args[0] === undefined ? true : params.args[0];
@@ -109,4 +157,4 @@ class Unknown extends Rule {
 }
 
 
-module.exports = [ObjectValidator, Keys, Unknown];
+module.exports = [ObjectValidator, Keys, Pattern, Unknown];

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,6 +33,7 @@ export const async = {
         }
         return fns;
     },
+
     /**
      * Attempts to run all funcs and callbacks positively on the first success.
      * @param  {Function[]} fns
@@ -68,6 +69,19 @@ export const async = {
             fns[i](cb);
         }
         return fns;
+    },
+
+    /**
+     * Map an array to a function in parallel.
+     * @param  {Array} collection
+     * @param  {Function} iteratee
+     * @param  {Function} callback
+     * @return {Function[]} fns
+     */
+    map(collection, iteratee, callback) {
+        return async.all(collection.map((item, index) =>
+            iteratee(item, index)
+        ), callback);
     },
 };
 

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -85,4 +85,27 @@ describe('object', () => {
             });
         });
     });
+
+    describe('pattern', () => {
+        it('validates unknown keys using a pattern', () => {
+            expect(Jo => Jo.object().pattern(/\d+/, Jo.number())).to.failOn({ b: 42 });
+            expect(Jo => Jo.object().pattern(/\w+/, Jo.number())).to.not.failOn({ b: 42 });
+        });
+
+        it('validates values using a pattern', () => {
+            expect(Jo => Jo.object().pattern(/\w+/, Jo.number())).to.failOn({ b: 'string' });
+            expect(Jo => Jo.object().pattern(/\w+/, Jo.number())).to.not.failOn({ b: 42 });
+        });
+
+        it('converts parameters', () => {
+            Jo.validate(
+                { a: '42' },
+                Jo.object().pattern(/\w+/, Jo.number()),
+                (err, value) => {
+                    expect(err).to.be.null;
+                    expect(value).to.deep.equal({ a: 42 });
+                }
+            );
+        });
+    });
 });


### PR DESCRIPTION
This implements the object.pattern() method from Joi, which lets you validate an object with unknown keys.
https://github.com/hapijs/joi/blob/master/API.md#objectpatternregex-schema