### PR TITLE
Add string prop and function comparator capabilities to Array.unique

### DIFF
--- a/lib/rules/array.js
+++ b/lib/rules/array.js
@@ -190,12 +190,14 @@ class Unique extends Rule {
         for (let i = 0; i < l; i++) {
             for (let k = i + 1; k < l; k++) {
                 let isEqual = false;
+                let compFn = eq;
                 if (this._compFn) {
-                    isEqual = this._compFn(v[i], v[k]);
-                } else if (this._key) {
+                    compFn = this._compFn;
+                }
+                if (this._key) {
                     isEqual = eq(get(v[i], this._key), get(v[k], this._key));
                 } else {
-                    isEqual = eq(v[i], v[k]);
+                    isEqual = compFn(v[i], v[k]);
                 }
                 if (isEqual) {
                     return callback(this.error(params, {

--- a/lib/rules/array.js
+++ b/lib/rules/array.js
@@ -187,17 +187,14 @@ class Unique extends Rule {
     validate(params, callback) {
         const v = params.value;
         const l = v.length;
+        const compare = this._compFn || eq;
         for (let i = 0; i < l; i++) {
             for (let k = i + 1; k < l; k++) {
                 let isEqual = false;
-                let compFn = eq;
-                if (this._compFn) {
-                    compFn = this._compFn;
-                }
                 if (this._key) {
                     isEqual = eq(get(v[i], this._key), get(v[k], this._key));
                 } else {
-                    isEqual = compFn(v[i], v[k]);
+                    isEqual = compare(v[i], v[k]);
                 }
                 if (isEqual) {
                     return callback(this.error(params, {

--- a/lib/rules/array.js
+++ b/lib/rules/array.js
@@ -1,6 +1,6 @@
 import Rule from '../types/rule';
 
-import { async, clone } from '../util';
+import { async, clone, get } from '../util';
 import eq from 'deep-equal';
 
 
@@ -175,12 +175,29 @@ class Length extends Rule {
 }
 
 class Unique extends Rule {
+    compile(params) {
+        const comp = params.args[0];
+        if (typeof comp === 'string') {
+            this._key = comp;
+        } else if (comp instanceof Function) {
+            this._compFn = comp;
+        }
+    }
+
     validate(params, callback) {
         const v = params.value;
         const l = v.length;
         for (let i = 0; i < l; i++) {
             for (let k = i + 1; k < l; k++) {
-                if (eq(v[i], v[k])) {
+                let isEqual = false;
+                if (this._compFn) {
+                    isEqual = this._compFn(v[i], v[k]);
+                } else if (this._key) {
+                    isEqual = eq(get(v[i], this._key), get(v[k], this._key));
+                } else {
+                    isEqual = eq(v[i], v[k]);
+                }
+                if (isEqual) {
                     return callback(this.error(params, {
                         violator: {
                             index: k,

--- a/lib/rules/boolean.js
+++ b/lib/rules/boolean.js
@@ -6,10 +6,10 @@ import SyncRule from '../types/syncRule';
 class BooleanValidator extends SyncRule {
 
     coerce(value) {
-        if (value === 'true' || Number(value) === 1) {
+        if (value === 'true') {
             return true;
         }
-        if (value === 'false' || Number(value) === 0) {
+        if (value === 'false') {
             return false;
         }
         return undefined;

--- a/lib/util.js
+++ b/lib/util.js
@@ -135,3 +135,26 @@ export function clone(obj) {
 export function escapeRegExp(str) {
     return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }
+
+/**
+ * Get the (nested) property defined by `propStr` out of the `obj`.
+ * @param {Object} obj The object to pull from.
+ * @param {String} propStr Property names string, separated by a `.`
+ */
+export function get(obj, propStr) {
+    if (typeof propStr !== 'string') {
+        throw new Error('propString should be a string');
+    }
+
+    const parts = propStr.split('.');
+    const l = parts.length;
+    let curr = obj;
+    for (let i = 0; i < l; ++i) {
+        const k = parts[i];
+        if (!curr[k]) {
+            return curr[k];
+        }
+        curr = curr[k];
+    }
+    return curr;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "debug": "node debug mocha -r test/_setup.js --compilers js:babel-register && eslint lib",
     "test-only": "mocha -r test/_setup.js --compilers js:babel-register",
-    "test": "mocha -r test/_setup.js --compilers js:babel-register && eslint lib",
+    "test:lint": "eslint lib",
+    "test:unit": "mocha -r test/_setup.js --compilers js:babel-register",
+    "test": "npm run test:unit && npm run test:lint",
     "bundle": "browserify lib/index.js -t babelify --presets es2015 -s Jo | ccjs --compilation_level=ADVANCED_OPTIMIZATIONS > jojen.min.js",
     "prepublish": "babel lib --out-dir dist && npm run bundle"
   },
@@ -45,7 +47,7 @@
   },
   "dependencies": {
     "deep-equal": "^1.0.1",
-    "joi": "^9.0.1",
+    "joi": "^10.3.1",
     "validator": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^8.0.0",
     "eslint-plugin-import": "^1.6.1",
+    "joi": "^10.3.1",
     "mocha": "^2.3.4",
     "progress": "^1.1.8"
   },
   "dependencies": {
     "deep-equal": "^1.0.1",
-    "joi": "^10.3.1",
     "validator": "^5.1.0"
   }
 }

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -53,5 +53,18 @@ describe('array', () => {
 
         expect((Jo) => Jo.array().unique()).not.to.failOn([{ a: 1 }, { a: 2 }, { b: 2 }]);
         expect((Jo) => Jo.array().unique()).to.failOn([{ a: 1 }, { a: 2 }, { a: 2 }]);
+
+        expect((Jo) => Jo.array().unique('a')).not.to.failOn([{ a: 1, b: 2 }, { a: 2, b: 3 }, { a: 3, b: 1 }]);
+        expect((Jo) => Jo.array().unique('a')).to.failOn([{ a: 1, b: 2 }, { a: 1, b: 3 }, { a: 3, b: 1 }]);
+        expect((Jo) => Jo.array().unique('a')).not.to.failOn([{ a: 1, b: 2 }, { a: 2, b: 2 }, { a: 3, b: 1 }]);
+
+        expect((Jo) => Jo.array().unique('a.b')).not.to.failOn([{ a: { b: 1 }}, { a: { b: 2 }}, { a: { b: 3 }}]);
+        expect((Jo) => Jo.array().unique('a.b')).to.failOn([{ a: { b: 1 }}, { a: { b: 1 }}, { a: { b: 2 }}]);
+
+        expect((Jo) => Jo.array().unique((a, b) => a.a === b.a)).not.to.failOn([{ a: 1, b: 2 }, { a: 2, b: 2 }, { a: 3, b: 1 }]);
+        expect((Jo) => Jo.array().unique((a, b) => a.a !== b.a)).to.failOn([{ a: 1, b: 2 }, { a: 2, b: 2 }, { a: 3, b: 1 }]);
+
+        expect((Jo) => Jo.array().unique((a, b) => true)).to.failOn([{ a: 1 }, { a: 2}]);
+        expect((Jo) => Jo.array().unique((a, b) => false)).not.to.failOn([{ a: 1 }, { a: 2}]);
     });
 });

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -64,7 +64,7 @@ describe('array', () => {
         expect((Jo) => Jo.array().unique((a, b) => a.a === b.a)).not.to.failOn([{ a: 1, b: 2 }, { a: 2, b: 2 }, { a: 3, b: 1 }]);
         expect((Jo) => Jo.array().unique((a, b) => a.a !== b.a)).to.failOn([{ a: 1, b: 2 }, { a: 2, b: 2 }, { a: 3, b: 1 }]);
 
-        expect((Jo) => Jo.array().unique((a, b) => true)).to.failOn([{ a: 1 }, { a: 2}]);
-        expect((Jo) => Jo.array().unique((a, b) => false)).not.to.failOn([{ a: 1 }, { a: 2}]);
+        expect((Jo) => Jo.array().unique((a, b) => true)).to.failOn([{ a: 1 }, { a: 2 }]);
+        expect((Jo) => Jo.array().unique((a, b) => false)).not.to.failOn([{ a: 1 }, { a: 2 }]);
     });
 });

--- a/test/boolean.test.js
+++ b/test/boolean.test.js
@@ -1,7 +1,7 @@
 describe('boolean', () => {
     it('will only validate booleans', () => {
-        expect(Jo => Jo.boolean()).to.not.failOn(1);
-        expect(Jo => Jo.boolean()).to.not.failOn(0);
+        expect(Jo => Jo.boolean()).to.failOn(1);
+        expect(Jo => Jo.boolean()).to.failOn(0);
         expect(Jo => Jo.boolean()).to.not.failOn('true');
         expect(Jo => Jo.boolean()).to.not.failOn('false');
         expect(Jo => Jo.boolean()).to.not.failOn(false);


### PR DESCRIPTION
In Joi 9 Array.unique could take an optional comparator function, we didn't have this capability.

In 10 they added the string deep path comparison (Works like lodash's .get method)

You provide a string like `a.b.c.d` and it would deep parse an object like `{a: {b: {c: {d: 'asdf'}}}}` and compare the `asdf` string.
For this, I implemented a variant to the .get method.

This brings us to Joi 10, but in Joi 10 .boolean() doesn't work on numbers anymore. For this reason this release should be a breaking change.